### PR TITLE
Portably handle paths so they stand a chance of working on non-Unix-like platforms

### DIFF
--- a/lib/File/Share.pm
+++ b/lib/File/Share.pm
@@ -25,9 +25,30 @@ sub dist_dir {
     my ($dist) = @_;
     (my $inc = $dist) =~ s!(-|::)!/!g;
     $inc .= '.pm';
-    my $path = $INC{$inc} || '';
-    $path =~ s/$inc$//;
-    $path = Cwd::realpath( File::Spec->catfile($path,'..') );
+
+    # dirname() without the quirks (like dirname("Foo.pm") eq ".")
+    my $inc_dir = (File::Spec->splitpath($inc))[1];
+
+    # Start with all relative components and symlinks resolved to avoid surprises
+    my $path = abs_path($INC{$inc} || '');
+
+    # Portably $path =~ s{\Q$inc\E$}{../}, that is, chop off the "module path"
+    # and go up a directory (under the assumption that all module paths are
+    # going to be at least one-level deep from the directory containing
+    # share/).  This works well when modules are under the traditional lib/
+    # layout.  If packages are loaded via some other, non-traditional means
+    # (e.g. an @INC hook), the assumption that
+    #
+    #   $INC{"Foo/Bar.pm"} =~ m{Foo/Bar\.pm$}
+    #
+    # may not hold.
+    my ($vol, $dir, $file) = File::Spec->splitpath($path);
+    my @dirs     = File::Spec->splitdir( File::Spec->canonpath($dir) );
+    my @inc_dirs = File::Spec->splitdir( File::Spec->canonpath($inc_dir) );
+    pop @dirs while pop @inc_dirs;
+    pop @dirs;
+    $path = File::Spec->catpath( $vol, File::Spec->catdir(@dirs), '' );
+
     if ($path and
         -d "$path/lib" and
         -e "$path/share"


### PR DESCRIPTION
Note that I haven't actually tested this on Win32 or platforms other
than Unix-likes.  I just rewrote the path handling to use File::Spec's
methods.
